### PR TITLE
Switch help from <table> based to <ul> based

### DIFF
--- a/lib/cognition/plugins/cognition/plugins/default/views/help.html.erb
+++ b/lib/cognition/plugins/cognition/plugins/default/views/help.html.erb
@@ -1,7 +1,5 @@
-<table>
+<ul>
 <% @help.each do |text| %>
-  <tr>
-    <td><%= CGI.escapeHTML(text) %></td>
-  </tr>
+  <li><%= CGI.escapeHTML(text) %></li>
 <% end %>
-</table>
+</ul>

--- a/lib/cognition/version.rb
+++ b/lib/cognition/version.rb
@@ -1,3 +1,3 @@
 module Cognition
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end


### PR DESCRIPTION
Since we're expanding usage here to include Once Campfire, we can't use `<table>` elements in bot responses.

This switches the help text to be rendered in `<ul>`/`<li>` elements as long as we set the `metadata[:type] = 'html'`.