### PR TITLE
Caller format change in new ruby

### DIFF
--- a/lib/cognition/plugins/base.rb
+++ b/lib/cognition/plugins/base.rb
@@ -45,7 +45,9 @@ module Cognition
 
       def render(opts = {})
         options = RENDER_DEFAULTS.merge(opts)
-        calling_method = caller[0][/`([^']*)'/, 1]
+        # ruby <= 3.3.6: test.rb:9:in `c'
+        # ruby >= 3.4.1: test.rb:9:in 'A#c'
+        calling_method = caller[0][/[`'](?:.*#)?([^']*)'/, 1]
         template = options[:template] || template_file(calling_method, options[:type], options[:extension])
         filter Tilt.new(template).render(self, options[:locals])
       rescue Errno::ENOENT => e


### PR DESCRIPTION
Account for a change in the format of the caller in ruby 3.4.2

Noted after https://github.com/basecamp/dash/pull/595 that various chatops commands are broken with:

> Cognition::Plugins::PluginTemplateNotFound: No such file or directory @ rb_sysopen - /usr/local/bundle/ruby/3.4.0/bundler/gems/cognition-aabb02e92514/lib/cognition/plugins/cognition/plugins/default/views/.html.erb /usr/local/bundle/ruby/3.4.0/bundler/gems/cognition-aabb02e92514/lib/cognition/plugins/base.rb:52:in 'Cognition::Plugins::Base#render'

Doesn't help they have no test coverage!

Tests okay via Dash local dev.